### PR TITLE
Add stylish countdown modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This project is a customizable timer website that includes a stopwatch and countdown timer functionality. 
 
-The webpage has buttons to control the timer, including start, pause, reset, and lap. Users can also switch between light and dark themes and adjust the minutes and seconds of the countdown timer using sliders. 
+The webpage has buttons to control the timer, including start, pause, reset, and lap. Users can also switch between light and dark themes and adjust the minutes and seconds of the countdown timer using sliders. The redesigned countdown timer now includes Pomodoro, Short Break, and Long Break modes for quick setup.
 
 The website is built using HTML, CSS, and JavaScript, and includes external libraries such as jQuery and Font Awesome. 
 It is designed to be user-friendly and functional for a variety of timing purposes, such as exercise routines, cooking, and more.

--- a/app.js
+++ b/app.js
@@ -129,8 +129,34 @@ document.addEventListener("click", (event) => {
 
 
 $(function() {
-  var timer, minutes, seconds, totalSeconds;
+  var timer, minutes = 0, seconds = 0, totalSeconds;
   var handle = $(".ui-slider-handle");
+  var modeSelect = $("#mode-select");
+
+  modeSelect.on("change", function() {
+    const mode = $(this).val();
+    if (mode === "pomodoro") {
+      minutes = 25;
+      seconds = 0;
+      $("#countdown-sliders").hide();
+    } else if (mode === "short-break") {
+      minutes = 5;
+      seconds = 0;
+      $("#countdown-sliders").hide();
+    } else if (mode === "long-break") {
+      minutes = 15;
+      seconds = 0;
+      $("#countdown-sliders").hide();
+    } else {
+      $("#countdown-sliders").show();
+      minutes = $("#countdown-minutes-slider").slider("value");
+      seconds = $("#countdown-seconds-slider").slider("value");
+    }
+    $("#countdown-minutes-slider").slider("value", minutes);
+    $("#countdown-seconds-slider").slider("value", seconds);
+    totalSeconds = minutes * 60 + seconds;
+    updateTimerDisplay();
+  });
 
   // Initialize the sliders
   $("#countdown-minutes-slider").slider({
@@ -216,6 +242,8 @@ $(function() {
     totalSeconds = 0;
     minutes = 0; // set minutes to 0
     seconds = 0; // set seconds to 0
+    $("#mode-select").val("custom");
+    $("#countdown-sliders").show();
     $("#countdown-minutes-slider").slider("value", 0);
     $("#countdown-seconds-slider").slider("value", 0);
     $("#countdown-minutes").text("00");

--- a/index.html
+++ b/index.html
@@ -38,15 +38,26 @@
           <span id="countdown-minutes">Timer</span>:<span id="countdown-seconds">00</span>
         </div>
         <div class="timer-controls">
-          <div class="slider-container">
-            <label for="countdown-minutes-slider">Minutes:</label>
-            <div id="countdown-minutes-slider"></div>
-            <div class="slider-value" id="countdown-minutes-value"></div>
+          <div id="countdown-sliders">
+            <div class="slider-container">
+              <label for="countdown-minutes-slider">Minutes:</label>
+              <div id="countdown-minutes-slider"></div>
+              <div class="slider-value" id="countdown-minutes-value"></div>
+            </div>
+            <div class="slider-container">
+              <label for="countdown-seconds-slider">Seconds:</label>
+              <div id="countdown-seconds-slider"></div>
+              <div class="slider-value" id="countdown-seconds-value"></div>
+            </div>
           </div>
-          <div class="slider-container">
-            <label for="countdown-seconds-slider">Seconds:</label>
-            <div id="countdown-seconds-slider"></div>
-            <div class="slider-value" id="countdown-seconds-value"></div>
+          <div class="mode-select">
+            <label for="mode-select">Mode:</label>
+            <select id="mode-select">
+              <option value="custom">Custom</option>
+              <option value="pomodoro">Pomodoro</option>
+              <option value="short-break">Short Break</option>
+              <option value="long-break">Long Break</option>
+            </select>
           </div>
           <button id="start-countdown">Start</button>
           <button id="pause-countdown">Pause</button>

--- a/style.css
+++ b/style.css
@@ -89,7 +89,8 @@ using flexbox and has a smooth transition effect for animations. */
   font-weight: bold;
   color: var(--text-color);
   text-shadow: 1px 1.5px #4CAF50;
-  
+  font-family: 'Courier New', monospace;
+  transition: color 0.5s ease;
 }
 
 /*Styling for the buttons in the timer controls.  */
@@ -156,6 +157,29 @@ the minutes and seconds of the countdown timer */
   opacity: 0;
   animation: fade-in 0.5s ease-in-out forwards;
   border-radius: 5%;
+}
+
+/* Style for the mode selector */
+.mode-select {
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#mode-select {
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid #ccc;
+  transition: background-color 0.3s ease;
+}
+
+#mode-select:hover {
+  background-color: #54ba57;
+  color: #000;
 }
 
 @keyframes fade-in {
@@ -461,6 +485,11 @@ the minutes and seconds of the countdown timer */
     font-size: 18px;
     padding: 10px 20px;
     margin: 10px;
+  }
+
+  #mode-select {
+    font-size: 16px;
+    padding: 6px 10px;
   }
 
   /* Top controls */


### PR DESCRIPTION
## Summary
- overhaul countdown timer screen with mode selector
- add responsive styling for new select box
- support Pomodoro, Short Break and Long Break presets in JS
- show custom mode by default and allow resetting to custom
- mention new modes in README

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f5253a304832daf617db3fc095661